### PR TITLE
feat: allow user to specify repo path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,88 @@
+use std::error::Error;
+use git2::Repository;
+
+pub mod providers;
+pub mod git_analysis;
+pub mod git;
+pub mod ui;
+pub mod modes;
+
+#[derive(Debug)]
+pub struct Config {
+    model: Box<dyn git_analysis::GitAnalyzer>,
+    repo_path: String,
+}
+
+#[derive(Debug)]
+pub struct FileAnalysis {
+    pub path: String,
+    pub explanation: String,
+}
+
+impl Config {
+    pub fn new(model: Box<dyn git_analysis::GitAnalyzer>, repo_path: Option<String>) -> Self {
+        Self { 
+            model,
+            repo_path: repo_path.unwrap_or_else(|| ".".to_string())
+        }
+    }
+
+    pub async fn generate_commit_message(&self, diff: &str) -> Result<String, Box<dyn Error>> {
+        self.model.generate_commit_message(diff).await
+    }
+
+    pub async fn analyze_changes(&self, repo: &Repository) -> Result<Vec<FileAnalysis>, Box<dyn Error>> {
+        let file_diffs = git::get_file_diffs(repo)?;
+        
+        let analysis_futures: Vec<_> = file_diffs.into_iter().map(|(path, diff)| {
+            let model = &self.model;
+            async move {
+                let explanation = model.analyze_file_changes(&diff).await?;
+                Ok::<FileAnalysis, Box<dyn Error>>(FileAnalysis {
+                    path,
+                    explanation,
+                })
+            }
+        }).collect();
+
+        futures::future::join_all(analysis_futures)
+            .await
+            .into_iter()
+            .collect()
+    }
+
+    pub async fn analyze_contributor(&self, stats: &str) -> Result<String, Box<dyn Error>> {
+        self.model.analyze_contributor(stats).await
+    }
+}
+
+pub async fn run(_repo_path: Option<String>) -> Result<(), Box<dyn Error>> {
+    let repo_path = loop {
+        let path = ui::get_repository_path(".")?;
+        match Repository::open(&path) {
+            Ok(_) => break path,
+            Err(_) => println!("Invalid git repository path. Please try again."),
+        }
+    };
+
+    let config = {
+        let providers = providers::get_available_providers();
+        let selected_idx = providers::select_provider(&providers)?;
+        Config::new(git_analysis::wrap_provider(providers.into_iter().nth(selected_idx).unwrap()), Some(repo_path))
+    };
+    
+    let repo = Repository::open(&config.repo_path)?;
+
+    loop {
+        let mode = ui::select_mode().await?;
+        mode.execute(&config, &repo).await?;
+
+        let options = ["✨ Do something else", "❌ Exit"];
+        if ui::show_selection_menu("What would you like to do next?", &options, 0)? == 1 {
+            break;
+        }
+        println!("\x1B[2J\x1B[1;1H"); // Clear screen
+    }
+    
+    Ok(())
+} 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,11 @@
-fn main() {
-    println!("Hello, world!");
+use dotenv;
+use merit_cli_demo::run;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    dotenv::dotenv().ok();
+    
+    let repo_path = env::args().nth(1);
+    run(repo_path).await
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,50 @@
+use std::error::Error;
+use dialoguer::{theme::ColorfulTheme, Select, Input};
+use indicatif::{ProgressBar, ProgressStyle};
+
+use crate::modes::Mode;
+
+pub fn create_spinner(message: &str) -> Result<ProgressBar, Box<dyn Error>> {
+    let spinner = ProgressBar::new_spinner();
+    spinner.set_style(
+        ProgressStyle::default_spinner()
+            .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈")
+            .template("{spinner} {msg}...")?
+    );
+    spinner.enable_steady_tick(std::time::Duration::from_millis(100));
+    spinner.set_message(format!("{}...", message));
+    Ok(spinner)
+}
+
+pub fn show_selection_menu<T: AsRef<str> + ToString>(prompt: &str, items: &[T], default: usize) -> Result<usize, Box<dyn Error>> {
+    Ok(Select::with_theme(&ColorfulTheme::default())
+        .with_prompt(prompt)
+        .items(items)
+        .default(default)
+        .interact()?)
+}
+
+pub async fn select_mode() -> Result<Mode, Box<dyn Error>> {
+    let modes = [
+        Mode::CommitMessage.description(),
+        Mode::FileAnalysis.description(),
+        Mode::ContributorAnalysis.description(),
+    ];
+    
+    let selection = show_selection_menu("What would you like to do?", &modes, 0)?;
+    
+    Ok(match selection {
+        0 => Mode::CommitMessage,
+        1 => Mode::FileAnalysis,
+        _ => Mode::ContributorAnalysis,
+    })
+}
+
+pub fn get_repository_path(default: &str) -> Result<String, Box<dyn Error>> {
+    let path: String = Input::with_theme(&ColorfulTheme::default())
+        .with_prompt("Enter repository path")
+        .default(default.into())
+        .allow_empty(true)
+        .interact()?;
+    Ok(if path.is_empty() { ".".to_string() } else { path })
+}


### PR DESCRIPTION
Allow a user to point the CLI tool at an repository on their machine rather than always using the current repo.
<img width="191" alt="image" src="https://github.com/user-attachments/assets/9e0f4d2b-2bb0-4eac-8510-bb265691b497" />
